### PR TITLE
修改README笔误，theme.js移动端适配

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pink-room theme inroduction
+# pink-room theme introduction
 I found there is not any pink colour theme in SiYuan's bazaar, so I decide to make one for myself.<br>
 The interface color of pink-room are mainly lightpink, white and beige.<br>
 If you have any questions, you can email me directly or submit issue（Please give me feedback \_(ÒωÓ๑ゝ∠)\_）

--- a/theme.js
+++ b/theme.js
@@ -52,8 +52,14 @@ window.theme.updateStyle = function (id, href) {
     }
 }
 
+/**简单判断目前思源是否是手机模式 */
+function isPhone() {
+    return document.getElementById("toolbarName") != null && document.getElementById("toolbar") == null;
+}
+
 setTimeout(() => {
-    const drag = document.getElementById('drag'); // 标题栏
+    let drag = document.getElementById('drag'); // 标题栏
+    if (isPhone()) drag = document.getElementById('toolbarName'); // 手机端的标题栏不太一样
     const themeStyle = document.getElementById('themeStyle'); // 当前主题引用路径
     if (drag && themeStyle) {
         const THEME_ROOT = new URL(themeStyle.href).pathname.replace('theme.css', ''); // 当前主题根目录
@@ -78,6 +84,20 @@ setTimeout(() => {
 
         /* 加载配色文件 */
         window.theme.updateStyle(window.theme.IDs.STYLE_COLOR, color_href);
+
+        if (isPhone()) {
+            // 如果是手机端，就直接给标题栏塞个图标，不然样式不对
+            const doc = new DOMParser().parseFromString(`<svg id="${window.theme.IDs.BUTTON_TOOLBAR_CHANGE_COLOR}" class="toolbar__icon"><use xlink:href="#iconTheme"></use></svg>`, 'text/html')
+            const svg_change_color = doc.getElementById(window.theme.IDs.BUTTON_TOOLBAR_CHANGE_COLOR)
+            svg_change_color.addEventListener('click', e => {
+                color_href = window.theme.iter.next().value;
+                localStorage.setItem(window.theme.IDs.LOCAL_STORAGE_COLOR_HREF, color_href);
+                setLocalStorageVal(window.theme.IDs.LOCAL_STORAGE_COLOR_HREF, color_href);
+                window.theme.updateStyle(window.theme.IDs.STYLE_COLOR, color_href);
+            });
+            drag.insertAdjacentElement('afterend', svg_change_color);
+            return;
+        }
 
         const button_change_color = document.createElement('button'); // 切换主题颜色按钮
         button_change_color.id = window.theme.IDs.BUTTON_TOOLBAR_CHANGE_COLOR;


### PR DESCRIPTION
和toy一样修改了移动端适配，现在移动端上面也有切换主题的图标了（如下视频）

建议好好检查一下修改部分的样式啥的


https://github.com/StarDustSheep/pink-room/assets/63407442/f8ca23df-0c77-460b-b5aa-39f49514a16e

